### PR TITLE
[Fix]: Make public dependencies in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,6 @@ target_include_directories(soundcoe
 target_link_libraries(soundcoe 
     PUBLIC
         soundcoe_headers
-    PRIVATE 
         OpenAL
         logcoe
 )


### PR DESCRIPTION
## [Fix]: Make public dependencies in CMake
Users cannot compile their projects when including `soundcoe.hpp`:

```cpp
#include <soundcoe.hpp>  // ❌ fatal error: AL/al.h: No such file or directory
```

The error occurs because:
- soundcoe's public headers include `AL/al.h` and others (like `logcoe.hpp`)
- OpenAL and logcoe were linked as `PRIVATE`, so include directories don't propagate
- User projects can't find OpenAL and logcoe headers when compiling

## Solution
Move OpenAL and logcoe from `PRIVATE` to `PUBLIC` dependency in `src/CMakeLists.txt`:

```diff
target_link_libraries(soundcoe 
    PUBLIC
        soundcoe_headers
+       OpenAL
+       logcoe
    PRIVATE 
-       OpenAL
-       logcoe
)
```

This ensures OpenAL's and logcoe's include directories are available to projects linking against soundcoe.