### PR TITLE
[Build]: Prepare for gamecoe integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build/
 .vscode/
 .cache/
-CLAUDE.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,43 +1,21 @@
-cmake_minimum_required(VERSION 3.14)
-project(soundcoe VERSION 0.0.1 LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.20)
+project(soundcoe LANGUAGES C CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(SOUNDCOE_SOURCE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(FetchContent)
 include(cmake/soundcoe_config.cmake)
 
 find_package(Threads REQUIRED)
 
-# Configure OpenAL: Use Emscripten's built-in OpenAL or fetch OpenAL-Soft
-if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
-    message(STATUS "[soundcoe] Using Emscripten's built-in OpenAL implementation")
-    # Emscripten provides its own OpenAL implementation via -lopenal linker flag
-    # No need to fetch or configure OpenAL-Soft
-else()
-    message(STATUS "[soundcoe] Fetching OpenAL-Soft from source...")
-    
-    FetchContent_Declare(
-        openal
-        GIT_REPOSITORY https://github.com/kcat/openal-soft.git
-        GIT_TAG 1.24.3
-    )
-    
-    configure_openal()
-    FetchContent_MakeAvailable(openal)
-    ignore_external_warnings(OpenAL)
-endif()
+fetch_openal_soft()
+fetch_logcoe()
 
-message(STATUS "[soundcoe] Fetching logcoe from source...")
-
-FetchContent_Declare(
-    logcoe
-    GIT_REPOSITORY https://github.com/nircoe/logcoe.git
-    GIT_TAG v0.1.0
-)
-FetchContent_MakeAvailable(logcoe)
-ignore_external_warnings(logcoe)
+generate_soundcoe_config_header()
 
 add_subdirectory(include)
 add_subdirectory(src)

--- a/cmake/config_header.cmake
+++ b/cmake/config_header.cmake
@@ -1,0 +1,12 @@
+function(generate_soundcoe_config_header)
+    set(SOUNDCOE_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/config")
+    set(SOUNDCOE_CONFIG_DIR ${SOUNDCOE_CONFIG_DIR} PARENT_SCOPE)
+
+    file(MAKE_DIRECTORY ${SOUNDCOE_CONFIG_DIR})
+
+    configure_file(
+        ${SOUNDCOE_SOURCE_ROOT_DIR}/cmake/soundcoe_config.hpp.in
+        ${SOUNDCOE_CONFIG_DIR}/soundcoe_config.hpp
+        @ONLY
+    )
+endfunction()

--- a/cmake/logcoe.cmake
+++ b/cmake/logcoe.cmake
@@ -1,0 +1,31 @@
+function(fetch_logcoe)
+    if(NOT DEFINED SOUNDCOE_USE_LOGCOE)
+        set(SOUNDCOE_USE_LOGCOE OFF)
+    endif()
+
+    if(SOUNDCOE_USE_LOGCOE)
+        message(STATUS "[soundcoe] Using logcoe for logging")
+        message(STATUS "[soundcoe] To disable: \"set(SOUNDCOE_USE_LOGCOE OFF)\" before fetching soundcoe")
+        set(SOUNDCOE_USE_LOGCOE 1 PARENT_SCOPE)
+
+        find_package(logcoe QUIET)
+
+        if(NOT logcoe_FOUND)
+            message(STATUS "[soundcoe] Fetching logcoe from source...")
+
+            FetchContent_Declare(
+                logcoe
+                GIT_REPOSITORY https://github.com/nircoe/logcoe.git
+                GIT_TAG v0.1.1
+            )
+            FetchContent_MakeAvailable(logcoe)
+            ignore_external_warnings(logcoe)
+        else()
+            message(STATUS "[soundcoe] Using existing logcoe")
+        endif()
+    else()
+        message(STATUS "[soundcoe] logcoe disabled")
+        message(STATUS "[soundcoe] To enable: \"set(SOUNDCOE_USE_LOGCOE ON)\" before fetching soundcoe")
+        set(SOUNDCOE_USE_LOGCOE 0 PARENT_SCOPE)
+    endif()
+endfunction()

--- a/cmake/openal_soft.cmake
+++ b/cmake/openal_soft.cmake
@@ -1,6 +1,28 @@
 # OpenAL-Soft Configuration for soundcoe
 # This file contains all OpenAL backend configurations for different platforms
 
+function(fetch_openal_soft)
+    # Configure OpenAL: Use Emscripten's built-in OpenAL or fetch OpenAL-Soft
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
+        message(STATUS "[soundcoe] Using Emscripten's built-in OpenAL implementation")
+        # Emscripten provides its own OpenAL implementation via -lopenal linker flag
+        # No need to fetch or configure OpenAL-Soft
+    else()
+        message(STATUS "[soundcoe] Fetching OpenAL-Soft from source...")
+        
+        FetchContent_Declare(
+            openal
+            GIT_REPOSITORY https://github.com/kcat/openal-soft.git
+            GIT_TAG 1.24.3
+        )
+        
+        configure_openal()
+        FetchContent_MakeAvailable(openal)
+        ignore_external_warnings(OpenAL)
+    endif()
+endfunction()
+
+
 # Helper function to disable all non-target backends
 function(disable_all_backends_except target_backends)
     # All known OpenAL-Soft backends

--- a/cmake/soundcoe_config.cmake
+++ b/cmake/soundcoe_config.cmake
@@ -2,6 +2,8 @@
 # Master include file for all soundcoe cmake utilities
 
 include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/openal_config.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/openal_soft.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/logcoe.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/config_header.cmake)
 
 # Future modules can be added here

--- a/cmake/soundcoe_config.hpp.in
+++ b/cmake/soundcoe_config.hpp.in
@@ -1,0 +1,32 @@
+// Auto-generated soundcoe configuration - DO NOT EDIT
+#pragma once
+
+#define SOUNDCOE_USE_LOGCOE @SOUNDCOE_USE_LOGCOE@
+
+#if !SOUNDCOE_USE_LOGCOE
+    #include <string>
+    namespace logcoe
+    {
+        enum class LogLevel { DEBUG, INFO, WARNING, ERROR, NONE };
+
+        inline void initialize([[maybe_unused]] LogLevel level = LogLevel::DEBUG,
+                                [[maybe_unused]] const std::string& defaultSource = "",
+                                [[maybe_unused]] bool enableConsole = true,
+                                [[maybe_unused]] bool enableFile = false,
+                                [[maybe_unused]] const std::string &filename = "logcoe.log") { }
+
+        inline void shutdown() { }
+        inline void debug([[maybe_unused]] const std::string &message, 
+                            [[maybe_unused]] const std::string &source = "",
+                            [[maybe_unused]] bool flush = true) { }
+        inline void info([[maybe_unused]] const std::string &message, 
+                            [[maybe_unused]] const std::string &source = "", 
+                            [[maybe_unused]] bool flush = true) { }
+        inline void warning([[maybe_unused]] const std::string &message, 
+                            [[maybe_unused]] const std::string &source = "", 
+                            [[maybe_unused]] bool flush = true) { }
+        inline void error([[maybe_unused]] const std::string &message, 
+                            [[maybe_unused]] const std::string &source = "", 
+                            [[maybe_unused]] bool flush = true) { }
+    } // namespace logcoe
+#endif

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -3,12 +3,13 @@ add_library(soundcoe_headers INTERFACE)
 target_include_directories(soundcoe_headers
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<INSTALL_INTERFACE:include>  
+        $<BUILD_INTERFACE:${SOUNDCOE_CONFIG_DIR}>
+        $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(soundcoe_headers
     INTERFACE
-        logcoe
+        $<$<BOOL:${SOUNDCOE_USE_LOGCOE}>:logcoe>
 )
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/soundcoe.hpp

--- a/include/soundcoe/core/types.hpp
+++ b/include/soundcoe/core/types.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <logcoe.hpp>
 #include <cmath>
 #include <string_view>
 #include <sstream>
 #include <limits>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,8 +22,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     target_link_libraries(soundcoe 
         PUBLIC
             soundcoe_headers
-            logcoe
             Threads::Threads
+        PRIVATE
+            $<$<BOOL:${SOUNDCOE_USE_LOGCOE}>:logcoe>
     )
     # Link with Emscripten's built-in OpenAL implementation
     target_link_options(soundcoe PRIVATE -lopenal)
@@ -31,9 +32,9 @@ else()
     target_link_libraries(soundcoe 
         PUBLIC
             soundcoe_headers
-            logcoe
             Threads::Threads
         PRIVATE
             OpenAL
+            $<$<BOOL:${SOUNDCOE_USE_LOGCOE}>:logcoe>
     )
 endif()

--- a/src/core/audio_context.cpp
+++ b/src/core/audio_context.cpp
@@ -1,7 +1,10 @@
 #include <soundcoe/core/audio_context.hpp>
 #include <soundcoe/core/error_handler.hpp>
-#include <logcoe.hpp>
 #include <iostream>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/src/core/error_handler.cpp
+++ b/src/core/error_handler.cpp
@@ -1,8 +1,11 @@
 #include <soundcoe/core/error_handler.hpp>
-#include <logcoe.hpp>
 #include <iostream>
 #include <sstream>
 #include <exception>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/src/playback/sound_manager.cpp
+++ b/src/playback/sound_manager.cpp
@@ -1,10 +1,13 @@
 #include <soundcoe/playback/sound_manager.hpp>
 #include <soundcoe/core/error_handler.hpp>
 #include <AL/al.h>
-#include <logcoe.hpp>
 #include <functional>
 #include <filesystem>
 #include <algorithm>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/src/resources/audio_data.cpp
+++ b/src/resources/audio_data.cpp
@@ -1,6 +1,5 @@
 #include <soundcoe/resources/audio_data.hpp>
 #include <soundcoe/core/error_handler.hpp>
-#include <logcoe.hpp>
 #include <exception>
 
 #define DR_WAV_IMPLEMENTATION
@@ -8,6 +7,11 @@
 #define DR_MP3_IMPLEMENTATION
 #include <dr_libs/dr_mp3.h>
 #include <stb/stb_vorbis.c>
+
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/src/resources/resource_manager.cpp
+++ b/src/resources/resource_manager.cpp
@@ -1,8 +1,11 @@
 #include <soundcoe/resources/resource_manager.hpp>
 #include <soundcoe/core/audio_context.hpp>
 #include <soundcoe/core/error_handler.hpp>
-#include <logcoe.hpp>
 #include <algorithm>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {
@@ -116,7 +119,7 @@ namespace soundcoe
             }
 
             logcoe::warning("ResourceManager::preloadDirectory: No audio files found in directory: " + subdirectory);
-            return false;
+            return true;
         }
 
         bool ResourceManager::unloadDirectory(const std::string &subdirectory)

--- a/src/resources/sound_buffer.cpp
+++ b/src/resources/sound_buffer.cpp
@@ -2,11 +2,14 @@
 #include <soundcoe/core/audio_context.hpp>
 #include <soundcoe/core/error_handler.hpp>
 #include <soundcoe/core/types.hpp>
-#include <logcoe.hpp>
 #include <iostream>
 #include <exception>
 #include <cassert>
 #include <filesystem>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/src/resources/sound_source.cpp
+++ b/src/resources/sound_source.cpp
@@ -1,7 +1,10 @@
 #include <soundcoe/resources/sound_source.hpp>
 #include <soundcoe/core/error_handler.hpp>
 #include <exception>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
 #include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/src/soundcoe.cpp
+++ b/src/soundcoe.cpp
@@ -1,7 +1,10 @@
 #include <soundcoe.hpp>
 #include <soundcoe/playback/sound_manager.hpp>
-#include <logcoe.hpp>
 #include <cassert>
+#include <soundcoe_config.hpp>
+#if SOUNDCOE_USE_LOGCOE
+#include <logcoe.hpp>
+#endif
 
 namespace soundcoe
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
     testcoe
     GIT_REPOSITORY https://github.com/nircoe/testcoe.git
-    GIT_TAG v0.1.0
+    GIT_TAG v0.1.1
 )
 
 FetchContent_MakeAvailable(testcoe)


### PR DESCRIPTION
- Upgrade CMake minimum version to 3.20 (match gamecoe)
- Upgrade C++ version to C++20 (match gamecoe)
- Organize CMake operation in .cmake files functions (fetch_openal_soft, fetch_logcoe)
- Upgrade testcoe to v0.1.1
- Upgrade logcoe to v0.1.1
- Make logcoe usage optional with SOUNDCOE_USE_LOGCOE
- Link logcoe private instead of public and only if SOUNDCOE_USE_LOGCOE
- Add generated header soundcoe_config.hpp for empty logcoe methods when !SOUNDCOE_USE_LOGCOE
- Wrap every include <logcoe.hpp> with if SOUNDCOE_USE_LOGCOE scope
- Modify ResourceManager::preloadDirectory() to return true if the directory is empty