### PR TITLE
[API]: Add init_config and initialize() overload

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -17,7 +17,7 @@ jobs:
           # Windows with MSVC
           - name: "Windows MSVC"
             compiler: msvc
-            cmake-generator: 'Visual Studio 17 2022'
+            cmake-generator: ''
             cmake-options: '-DSOUNDCOE_BUILD_TESTS=ON'
             
           # Windows with MinGW (GCC)
@@ -45,7 +45,12 @@ jobs:
 
     - name: Configure CMake
       run: |
-        cmake -B build -G "${{ matrix.cmake-generator }}" ${{ matrix.cmake-options }}
+        if [ -n "${{ matrix.cmake-generator }}" ]; then
+          cmake -B build -G "${{ matrix.cmake-generator }}" ${{ matrix.cmake-options }}
+        else
+          cmake -B build ${{ matrix.cmake-options }}
+        fi
+      shell: bash
 
     - name: Build
       run: |

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ soundcoe::initialize("./audio");  // relative to executable
 // Full configuration
 soundcoe::initialize(
     "./audio",        // Audio root directory (relative to executable)
-    32,              // Max sources (default: 32)
-    64,              // Cache size MB (default: 64, use soundcoe::UNLIMITED_CACHE for no limit)
+    64,              // Max sources (default: 64)
+    soundcoe::UNLIMITED_CACHE, // Cache size MB (default: unlimited, cap it once you've profiled real usage)
     "sfx",           // Sound subdirectory inside each scene/general (default: "sfx")
     "music",         // Music subdirectory inside each scene/general (default: "music")
-    LogLevel::INFO   // Log level (default: INFO)
+    LogLevel::DEBUG  // Log level (default: DEBUG)
 );
 
 // Clean shutdown

--- a/cmake/soundcoe_config.hpp.in
+++ b/cmake/soundcoe_config.hpp.in
@@ -16,6 +16,7 @@
                                 [[maybe_unused]] const std::string &filename = "logcoe.log") { }
 
         inline void shutdown() { }
+        inline void setLogLevel([[maybe_unused]] LogLevel level) { }
         inline void debug([[maybe_unused]] const std::string &message, 
                             [[maybe_unused]] const std::string &source = "",
                             [[maybe_unused]] bool flush = true) { }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ int main() {
         128,          // Cache size MB (adjust based on your audio assets, or soundcoe::UNLIMITED_CACHE)
         "sfx",        // Sound subdirectory inside each scene/general
         "music",      // Music subdirectory inside each scene/general
-        LogLevel::INFO // Log level (default: INFO)
+        LogLevel::DEBUG // Log level (default: DEBUG)
     );
     
     soundcoe::preloadScene("level1");
@@ -182,8 +182,8 @@ soundcoe::initialize("./audio", 32, soundcoe::UNLIMITED_CACHE);
 ```cpp
 // Configure source pool based on your game - choose how many sources that you would like! remember it is the maximum concurrent amount.
 soundcoe::initialize("./audio", 16, 64);     // 16 sources for games with less concurrent audio
-soundcoe::initialize("./audio", 32, 64);     // 32 sources - default
-soundcoe::initialize("./audio", 64, 128);    // 64 sources for game with more concurrent audio
+soundcoe::initialize("./audio", 64, 64);     // 64 sources - default
+soundcoe::initialize("./audio", 128, 128);   // 128 sources for game with more concurrent audio
 ```
 
 ### Supported Audio Format
@@ -454,7 +454,7 @@ cmake -B build \
 ### Caching Strategy
 - **LRU Eviction**: Least recently used buffers removed first
 - **Size Limits**: Configurable maximum cache size in MB
-- **Unlimited Cache**: Use `soundcoe::UNLIMITED_CACHE` for development/profiling to measure peak memory usage
+- **Unlimited Cache by Default**: `initialize()` defaults `maxCacheSizeMB` to `soundcoe::UNLIMITED_CACHE`, so nothing evicts during development/profiling; pass a real budget once you've measured peak memory usage
 - **Usage Tracking**: Statistical data for optimization decisions
 
 ## Audio Format Integration

--- a/include/soundcoe.hpp
+++ b/include/soundcoe.hpp
@@ -16,6 +16,21 @@ namespace soundcoe
 namespace soundcoe
 {
     /**
+     * @brief Configuration bundle for initialize(), for callers that want to hold/forward init
+     *        settings as a single value (e.g. gamecoe's game::create()) instead of six positional
+     *        arguments.
+     */
+    struct init_config
+    {
+        std::string audioRootDirectory = "assets/audio";
+        std::string soundSubdir = "sfx";
+        std::string musicSubdir = "music";
+        size_t maxSources = 64;
+        size_t maxCacheSizeMB = UNLIMITED_CACHE;
+        LogLevel level = LogLevel::DEBUG;
+    };
+
+    /**
      * @brief Initializes soundcoe with the specified configuration.
      *
      * Sets up an audio context, resource management, and loads the "general" audio directory if it exists.
@@ -26,17 +41,17 @@ namespace soundcoe
      *                          during initialization if exists, and will be loaded till soundcoe::shutdown() will be called.
      * @param maxSources Maximum number of concurrent audio sources that can be played simultaneously.
      *                   Higher values allow more concurrent audio but consume more system resources.
-     *                   Default is 32.
+     *                   Default is 64.
      * @param maxCacheSizeMB Maximum size in megabytes for the audio buffer cache. Larger values keep
      *                       more audio files in memory for faster playback but consume more RAM.
-     *                       Use soundcoe::UNLIMITED_CACHE during development to measure actual usage.
-     *                       Default is 64 MB.
+     *                       Default is soundcoe::UNLIMITED_CACHE, so nothing evicts during development;
+     *                       set a real budget once you've profiled actual usage for shipping.
      * @param soundSubdir Name of the subdirectory within each audio directory (general, scenes) that
      *                    contains sound effects. Default is "sfx".
      * @param musicSubdir Name of the subdirectory within each audio directory (general, scenes) that
      *                    contains music files. Default is "music".
      * @param level Logging level for soundcoe operations. Controls the verbosity of log output.
-     *              Default is LogLevel::INFO.
+     *              Default is LogLevel::DEBUG.
      *
      * @return true if initialization was successful, false if it failed (e.g., invalid directory,
      *         OpenAL initialization failure, or system already initialized).
@@ -56,9 +71,15 @@ namespace soundcoe
      *     // Handle initialization failure
      * }
      */
-    bool initialize(const std::string &audioRootDirectory, size_t maxSources = 32,
-                           size_t maxCacheSizeMB = 64, const std::string &soundSubdir = "sfx",
-                           const std::string &musicSubdir = "music", LogLevel level = LogLevel::INFO);
+    bool initialize(const std::string &audioRootDirectory, size_t maxSources = 64,
+                           size_t maxCacheSizeMB = UNLIMITED_CACHE, const std::string &soundSubdir = "sfx",
+                           const std::string &musicSubdir = "music", LogLevel level = LogLevel::DEBUG);
+
+    /**
+     * @brief Initializes soundcoe from an init_config bundle. Forwards to the flat-parameter
+     *        overload above - see its documentation for behavior/return value.
+     */
+    bool initialize(const init_config &config);
 
     /**
      * @brief Shuts down soundcoe and releases all resources.

--- a/include/soundcoe/playback/sound_manager.hpp
+++ b/include/soundcoe/playback/sound_manager.hpp
@@ -137,9 +137,9 @@ namespace soundcoe
             SoundManager();
             ~SoundManager();
 
-            bool initialize(const std::string &audioRootDirectory, size_t maxSources = 32,
-                            size_t maxCacheSizeMB = 64, const std::string &soundSubdir = "sfx",
-                            const std::string &musicSubdir = "music", LogLevel level = LogLevel::INFO);
+            bool initialize(const std::string &audioRootDirectory, size_t maxSources = 64,
+                            size_t maxCacheSizeMB = UNLIMITED_CACHE, const std::string &soundSubdir = "sfx",
+                            const std::string &musicSubdir = "music", LogLevel level = LogLevel::DEBUG);
             void shutdown();
             bool isInitialized() const;
 

--- a/include/soundcoe/resources/resource_manager.hpp
+++ b/include/soundcoe/resources/resource_manager.hpp
@@ -38,7 +38,7 @@ namespace soundcoe
             AudioContext m_audioContext;
             bool m_initialized = false;
             std::filesystem::path m_audioRootDirectory;
-            size_t m_maxSources = 32;
+            size_t m_maxSources = 64;
             mutable std::mutex m_mutex;
 
             std::vector<SourceAllocation> m_sourcePool;
@@ -66,8 +66,8 @@ namespace soundcoe
             ResourceManager();
             ~ResourceManager();
 
-            void initialize(const std::string &audioRootDirectory, size_t maxSources = 32,
-                            size_t maxCacheSizeMB = 64);
+            void initialize(const std::string &audioRootDirectory, size_t maxSources = 64,
+                            size_t maxCacheSizeMB = UNLIMITED_CACHE);
             void shutdown();
             bool isInitialized() const;
 

--- a/src/soundcoe.cpp
+++ b/src/soundcoe.cpp
@@ -25,6 +25,12 @@ namespace soundcoe
                                                             soundSubdir, musicSubdir, level);
     }
 
+    bool initialize(const init_config &config)
+    {
+        return initialize(config.audioRootDirectory, config.maxSources, config.maxCacheSizeMB,
+                          config.soundSubdir, config.musicSubdir, config.level);
+    }
+
     void shutdown()
     {
         detail::getSoundManagerInstance().shutdown();


### PR DESCRIPTION
- Add init_config struct and initialize(const init_config&) overload
- Add setLogLevel stub to the generated logcoe fallback
- Default maxCacheSizeMB to UNLIMITED_CACHE
- Default maxSources to 64
- Default LogLevel::DEBUG instead of INFO
- Update README/ARCHITECTURE examples to match
- Make Windows MSVC CI to use latest generator instead of hard-coded version